### PR TITLE
Detect unintended reset of the SX1301 and terminate packet forwarder

### DIFF
--- a/poly_pkt_fwd/src/poly_pkt_fwd.c
+++ b/poly_pkt_fwd/src/poly_pkt_fwd.c
@@ -1430,6 +1430,12 @@ int main(void)
 			report_ready = true;
 			pthread_mutex_unlock(&mx_stat_rep);
 		}
+
+		uint32_t trig_cnt_us;
+		if (lgw_get_trigcnt(&trig_cnt_us) == LGW_HAL_SUCCESS && trig_cnt_us == 0x7E000000) {
+			MSG("ERROR: [main] unintended SX1301 reset detected, terminating packet forwarder.\n");
+			exit(EXIT_FAILURE);
+		}
 	}
 	
 	/* wait for upstream thread to finish (1 fetch cycle max) */


### PR DESCRIPTION
If the SX1301 resets, the host does not handle that well and the packet forwarder keeps running but no radio packet are received anymore.

This has been reported in the forum: http://forum.thethingsnetwork.org/t/imst-ic880a-rpi-gateway-hangs-every-few-weeks/2027/68

I tried other solutions without touching the packet forwarder code, but didn't work, so this seems like the best solution. The code simply terminates the packet forwarder in the event of an unintended reset, and because the pck_fwd runs as a service with auto-restart, it will restart immediately.

I (and other people, see the forum thread) have tested this on the ic880a + RPi and it solves the problem. I believe it won't affect any other platform, because other boards filter this "unintended reset" on hardware (probably with some passive filtering), but it would be best if someone tests this in other platforms.
