### PR TITLE
Removed necessity of a config file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,5 +104,5 @@ azure-binaries:
   image: registry.gitlab.com/thethingsindustries/upload
   script:
     - cd release
-    - export STORAGE_CONTAINER=packet-forwarder STORAGE_KEY=$AZURE_STORAGE_KEY ZIP=true TGZ=true PREFIX=$CI_BUILD_REF_NAME/
+    - export STORAGE_CONTAINER=packet-forwarder STORAGE_KEY=$AZURE_STORAGE_KEY ZIP=false TGZ=false PREFIX=$CI_BUILD_REF_NAME/
     - upload *

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -3,7 +3,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/TheThingsNetwork/packet_forwarder/util"
@@ -21,10 +20,6 @@ The first argument is used as the storage location to the configuration file. If
 
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := util.GetLogger()
-		filePath := fmt.Sprintf("%s/.pktfwd.yml", os.Getenv("HOME"))
-		if len(args) > 0 {
-			filePath = args[0]
-		}
 
 		ctx.Info("If you haven't registered your gateway yet, you can register it either with the console, or with `ttnctl`.")
 
@@ -62,14 +57,14 @@ The first argument is used as the storage location to the configuration file. If
 			util.GetLogger().WithError(err).Fatal("Failed to generate YAML")
 		}
 
-		f, err := os.Create(filePath)
+		f, err := os.Create(cfgFile)
 		if err != nil {
 			util.GetLogger().WithError(err).Fatal("Failed to create file")
 		}
 		defer f.Close()
 
 		f.Write(output)
-		ctx.WithField("ConfigFilePath", filePath).Info("New configuration file saved")
+		ctx.WithField("ConfigFilePath", cfgFile).Info("New configuration file saved")
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/TheThingsNetwork/packet_forwarder/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -35,6 +36,10 @@ func init() {
 }
 
 func initConfig() {
+	if cfgFile == "" {
+		cfgFile = util.GetConfigFile()
+	}
+
 	viper.SetConfigType("yaml")
 	viper.SetConfigName(".pktfwd")
 	viper.AddConfigPath("$HOME")
@@ -46,9 +51,10 @@ func initConfig() {
 		viper.SetConfigFile(cfgFile)
 	}
 
-	err := viper.ReadInConfig()
-	if err != nil {
-		fmt.Println("Error when reading config file:", err)
-		os.Exit(1)
+	if _, err := os.Stat(cfgFile); err == nil {
+		err := viper.ReadInConfig()
+		if err != nil {
+			fmt.Println("Error when reading config file:", err, "; If the file doesn't exist yet, create .pktfwd.yml by using the `configure` command.")
+		}
 	}
 }

--- a/util/system.go
+++ b/util/system.go
@@ -2,7 +2,13 @@
 
 package util
 
-import "time"
+import (
+	"os"
+	"path"
+	"time"
+
+	"github.com/spf13/viper"
+)
 
 // TXTimestamp allows to wrap a router.DownlinkMessage.GatewayConfiguration.Timestamp
 type TXTimestamp uint32
@@ -13,4 +19,35 @@ func (ts TXTimestamp) GetAsDuration() time.Duration {
 
 func TXTimestampFromDuration(d time.Duration) TXTimestamp {
 	return TXTimestamp(d.Nanoseconds() / 1000.0)
+}
+
+func GetConfigFile() string {
+	flag := viper.GetString("config")
+
+	home := os.Getenv("HOME")
+	homeyml := ""
+	homeyaml := ""
+
+	if home != "" {
+		homeyml = path.Join(home, ".pktfwd.yml")
+		homeyaml = path.Join(home, ".pktfwd.yaml")
+	}
+
+	try_files := []string{
+		flag,
+		homeyml,
+		homeyaml,
+	}
+
+	// find a file that exists, and use that
+	for _, file := range try_files {
+		if file != "" {
+			if _, err := os.Stat(file); err == nil {
+				return file
+			}
+		}
+	}
+
+	// no file found, set up correct fallback
+	return homeyml
 }


### PR DESCRIPTION
Fixes the catch-22 situation of #13 where the program requires a configuration file to start, even to use the `configure` command.