### PR TITLE
Network Client doesn't try to reconnect to an empty router

### DIFF
--- a/pktfwd/network.go
+++ b/pktfwd/network.go
@@ -205,12 +205,16 @@ func (c *TTNClient) getRouterClient(ctx log.Interface, ttnConfig TTNConfig) (rou
 	if ttnConfig.Router == "" {
 		gw, err := c.account.FindGateway(c.GatewayID())
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "Couldn't fetch the gateway information from the account server")
 		}
 
-		routerConn, err = connectToRouter(c.ctx, discoveryClient, gw.Router.ID)
-		if err != nil {
-			ctx.WithError(err).WithField("RouterID", gw.Router.ID).Warn("Couldn't connect to main router - trying to connect to fallback routers")
+		if gw.Router.ID != "" {
+			routerConn, err = connectToRouter(c.ctx.WithField("RouterID", gw.Router.ID), discoveryClient, gw.Router.ID)
+		}
+		if gw.Router.ID == "" || err != nil {
+			if err != nil {
+				ctx.WithError(err).WithField("RouterID", gw.Router.ID).Warn("Couldn't connect to main router - trying to connect to fallback routers")
+			}
 			fallbackRouters := gw.FallbackRouters
 			if len(fallbackRouters) == 0 {
 				ctx.Warn("No fallback routers in memory for this gateway - loading all routers")
@@ -221,12 +225,12 @@ func (c *TTNClient) getRouterClient(ctx log.Interface, ttnConfig TTNConfig) (rou
 				}
 				routerConn, err = c.getLowestLatencyRouterFromAnnouncements(discoveryClient, routers)
 				if err != nil {
-					return nil, err
+					return nil, errors.Wrap(err, "couldn't figure out the latest latency router")
 				}
 			} else {
 				routerConn, err = c.getLowestLatencyRouter(discoveryClient, fallbackRouters)
 				if err != nil {
-					return nil, err
+					return nil, errors.Wrap(err, "couldn't figure out the latest latency router")
 				}
 			}
 			defer func() {
@@ -237,7 +241,7 @@ func (c *TTNClient) getRouterClient(ctx log.Interface, ttnConfig TTNConfig) (rou
 	} else {
 		routerConn, err = connectToRouter(ctx, discoveryClient, ttnConfig.Router)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "couldn't connect to user-specified router")
 		}
 		ctx.Info("Connected to router")
 	}

--- a/pktfwd/network.go
+++ b/pktfwd/network.go
@@ -225,12 +225,12 @@ func (c *TTNClient) getRouterClient(ctx log.Interface, ttnConfig TTNConfig) (rou
 				}
 				routerConn, err = c.getLowestLatencyRouterFromAnnouncements(discoveryClient, routers)
 				if err != nil {
-					return nil, errors.Wrap(err, "couldn't figure out the latest latency router")
+					return nil, errors.Wrap(err, "Couldn't figure out the lowest latency router")
 				}
 			} else {
 				routerConn, err = c.getLowestLatencyRouter(discoveryClient, fallbackRouters)
 				if err != nil {
-					return nil, errors.Wrap(err, "couldn't figure out the latest latency router")
+					return nil, errors.Wrap(err, "Couldn't figure out the lowest latency router")
 				}
 			}
 			defer func() {
@@ -241,7 +241,7 @@ func (c *TTNClient) getRouterClient(ctx log.Interface, ttnConfig TTNConfig) (rou
 	} else {
 		routerConn, err = connectToRouter(ctx, discoveryClient, ttnConfig.Router)
 		if err != nil {
-			return nil, errors.Wrap(err, "couldn't connect to user-specified router")
+			return nil, errors.Wrap(err, "Couldn't connect to user-specified router")
 		}
 		ctx.Info("Connected to router")
 	}


### PR DESCRIPTION
This PR adds and fixes:
+ The packet forwarder's network client doesn't try to reconnect to an empty router anymore.
+ Added errors wrapping, for more explicit errors.