### PR TITLE
Sending account server location

### DIFF
--- a/pktfwd/gps.go
+++ b/pktfwd/gps.go
@@ -18,7 +18,7 @@ import (
 // tries to activate it.
 func enableGPS(ctx log.Interface, gpsPath string) (err error) {
 	if gpsPath == "" {
-		ctx.Warn("No GPS configured, ignoring")
+		ctx.Warn("No GPS chip configured, ignoring")
 		return nil
 	}
 

--- a/pktfwd/manager.go
+++ b/pktfwd/manager.go
@@ -40,9 +40,11 @@ type Manager struct {
 
 func NewManager(ctx log.Interface, conf util.Config, netClient NetworkClient, gpsPath string, runConfig TTNConfig) Manager {
 	isGPS := gpsPath != ""
-	statusMgr := NewStatusManager(ctx, netClient.FrequencyPlan(), runConfig.GatewayDescription, isGPS)
+	statusMgr := NewStatusManager(ctx, netClient.FrequencyPlan(), runConfig.GatewayDescription, isGPS, netClient.DefaultLocation())
+
 	bootTimeSetters := NewMultipleBootTimeSetter()
 	bootTimeSetters.Add(statusMgr)
+
 	return Manager{
 		ctx:             ctx,
 		conf:            conf,

--- a/pktfwd/network.go
+++ b/pktfwd/network.go
@@ -33,6 +33,7 @@ type TTNConfig struct {
 }
 
 type TTNClient struct {
+	antennaLocation   *account.AntennaLocation
 	currentRouterConn *grpc.ClientConn
 	ctx               log.Interface
 	uplinkStream      router.UplinkStream
@@ -61,6 +62,7 @@ type NetworkClient interface {
 	Downlinks() <-chan *router.DownlinkMessage
 	GatewayID() string
 	Ping() (time.Duration, error)
+	DefaultLocation() *account.AntennaLocation
 	Stop()
 }
 
@@ -93,6 +95,10 @@ func connectToRouter(ctx log.Interface, discoveryClient discovery.Client, router
 
 	ctx.Info("Connecting to router...")
 	return announcement.Dial()
+}
+
+func (c *TTNClient) DefaultLocation() *account.AntennaLocation {
+	return c.antennaLocation
 }
 
 func (c *TTNClient) FrequencyPlan() string {
@@ -291,6 +297,7 @@ func (c *TTNClient) fetchAccountServerInfo(gatewayID string) error {
 	if err != nil {
 		return errors.Wrap(err, "Account server error")
 	}
+	c.antennaLocation = gw.AntennaLocation
 	c.token = gw.Token.AccessToken
 	c.frequencyPlan = gw.FrequencyPlan
 	return nil


### PR DESCRIPTION
Until now, the packet forwarder didn't send any location in its status messages unless there was a GPS chip configured from which location could be retrieved. With this PR, the packet forwarder sends the account server location to the router as GPS location, unless a valid location is retrieved from the GPS chip. The wording has also been clarified to make the difference between GPS location and location in general.