### PR TITLE
Better uplink logging

### DIFF
--- a/pktfwd/manager.go
+++ b/pktfwd/manager.go
@@ -151,13 +151,13 @@ func (m *Manager) uplinkRoutine(bgCtx context.Context, errc chan error, runStart
 			}
 		}
 
-		validPackets, err := wrapUplinkPayload(packets, m.ignoreCRC, m.netClient.GatewayID())
+		validPackets, err := wrapUplinkPayload(m.ctx, packets, m.ignoreCRC, m.netClient.GatewayID())
 		if err != nil {
 			continue
 		}
 		m.statusMgr.HandledRXBatch(len(validPackets), len(packets))
 		if len(validPackets) == 0 {
-			m.ctx.Warn("Packets received, but with invalid CRC - ignoring")
+			// Packets received, but with invalid CRC - ignoring
 			time.Sleep(m.uplinkPollingRate)
 			continue
 		}

--- a/pktfwd/manager.go
+++ b/pktfwd/manager.go
@@ -151,10 +151,7 @@ func (m *Manager) uplinkRoutine(bgCtx context.Context, errc chan error, runStart
 			}
 		}
 
-		validPackets, err := wrapUplinkPayload(m.ctx, packets, m.ignoreCRC, m.netClient.GatewayID())
-		if err != nil {
-			continue
-		}
+		validPackets := wrapUplinkPayload(m.ctx, packets, m.ignoreCRC, m.netClient.GatewayID())
 		m.statusMgr.HandledRXBatch(len(validPackets), len(packets))
 		if len(validPackets) == 0 {
 			// Packets received, but with invalid CRC - ignoring

--- a/pktfwd/status.go
+++ b/pktfwd/status.go
@@ -70,8 +70,8 @@ func (s *statusManager) SentTX() {
 }
 
 func (s *statusManager) HandledRXBatch(received, valid int) {
-	atomic.AddUint32(&s.rxIn, 1)
-	atomic.AddUint32(&s.rxOk, 1)
+	atomic.AddUint32(&s.rxIn, uint32(received))
+	atomic.AddUint32(&s.rxOk, uint32(valid))
 }
 
 func getOSInfo() *gateway.Status_OSMetrics {

--- a/pktfwd/uplinks.go
+++ b/pktfwd/uplinks.go
@@ -3,7 +3,7 @@
 package pktfwd
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/TheThingsNetwork/go-utils/log"
 	"github.com/TheThingsNetwork/packet_forwarder/wrapper"
@@ -79,7 +79,7 @@ func initLoRaData(packet wrapper.Packet) (lorawan.Metadata, error) {
 	} else if packet.Modulation == wrapper.ModulationFSK {
 		loRaData = newFSKMetadata(packet)
 	} else {
-		return loRaData, errors.New("Received packet with unknown modulation")
+		return loRaData, fmt.Errorf("Received packet with unknown modulation (modulation value code: %v)", packet.Modulation)
 	}
 
 	return loRaData, nil

--- a/wrapper/common.go
+++ b/wrapper/common.go
@@ -3,7 +3,7 @@
 package wrapper
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/TheThingsNetwork/ttn/api/gateway"
 )
@@ -42,19 +42,19 @@ func (p Packet) DatarateString() (string, error) {
 	if val, ok := datarateString[p.Datarate]; ok {
 		return val, nil
 	}
-	return "", errors.New("LoRa packet with unknown datarate")
+	return "", fmt.Errorf("LoRa packet with unknown datarate (datarate value code: %v)", p.Datarate)
 }
 
 func (p Packet) BandwidthString() (string, error) {
 	if val, ok := bandwidthString[p.Bandwidth]; ok {
 		return val, nil
 	}
-	return "", errors.New("LoRa packet with unknown bandwidth")
+	return "", fmt.Errorf("LoRa packet with unknown bandwidth (bandwidth value code: %v)", p.Bandwidth)
 }
 
 func (p Packet) CoderateString() (string, error) {
 	if val, ok := coderateString[p.Coderate]; ok {
 		return val, nil
 	}
-	return "", errors.New("LoRa packet with unknown coderate")
+	return "", fmt.Errorf("LoRa packet with unknown coderate (coderate value code: %v)", p.Coderate)
 }


### PR DESCRIPTION
When an invalid uplink was processed, the `wrapUplinkPayload` function silently failed, along with all the other uplinks in the batch received from the concentrator.

With these modifications, only the invalid uplink is ignored - and the root of the error for the invalid uplink is logged.

This is related to issue #36.

![screen shot 2017-05-29 at 09 58 51](https://cloud.githubusercontent.com/assets/8390508/26541349/9ddd4d00-4455-11e7-86a8-4ad9715ed416.png)
