### PR TITLE
Fix SPI configuration file generation on `make build`

### DIFF
--- a/.make/halv1/build.make
+++ b/.make/halv1/build.make
@@ -9,7 +9,7 @@ else
 endif
 
 # Build the HAL
-hal.build: lora_gateway/libloragw/libloragw.a
+hal.build: lora_gateway/libloragw/inc/$(PLATFORM).h lora_gateway/libloragw/libloragw.a
 
 ### library.cfg configuration file processing
 


### PR DESCRIPTION
Currently, `make build` fails if no platform is specified - this is because the `default.h` file, that contains the SPI configuration determined at build (or filled in by the user with environment variables) for `PLATFORM=default`, is not generated according to the Makefile recipes.
This PR fixes the Makefile, to make sure that the SPI configuration file is found or generated at build.