### PR TITLE
Changed arithmetics for RTT

### DIFF
--- a/pktfwd/manager.go
+++ b/pktfwd/manager.go
@@ -210,6 +210,7 @@ func (m *Manager) statusRoutine(bgCtx context.Context, errC chan error) {
 		select {
 		case <-time.After(statusRoutineSleepRate):
 			rtt, err := m.netClient.Ping()
+			m.ctx.WithField("RTT", rtt).Debug("Ping to the router successful")
 			if err != nil {
 				errC <- errors.Wrap(err, "Network server health check error")
 				continue

--- a/pktfwd/network.go
+++ b/pktfwd/network.go
@@ -392,6 +392,7 @@ func (c *TTNClient) SendStatus(status gateway.Status) error {
 		"Latitude":          status.GetGps().GetLatitude(),
 		"Longitude":         status.GetGps().GetLongitude(),
 		"Altitude":          status.GetGps().GetAltitude(),
+		"RTT":               status.GetRtt(),
 	}).Info("Sending status to the network server")
 	err = c.statusStream.Send(&status)
 	if err != nil {

--- a/pktfwd/status.go
+++ b/pktfwd/status.go
@@ -135,7 +135,7 @@ func (s *statusManager) GenerateStatus(rtt time.Duration) (*gateway.Status, erro
 		// Contact-email: TODO once it has been implemented on the account server
 		ContactEmail: "",
 		Description:  s.gatewayDescription,
-		Rtt:          uint32((rtt.Nanoseconds() / 1000000) / (1 << 32)),
+		Rtt:          uint32(rtt.Nanoseconds() / 1000000),
 		RxIn:         atomic.LoadUint32(&s.rxIn),
 		RxOk:         atomic.LoadUint32(&s.rxOk),
 		TxIn:         atomic.LoadUint32(&s.txIn),


### PR DESCRIPTION
The arithmetics operated on the RTT before sending it to the network server were impromper. This PR fixes the operation, and adds logging for this value.