### PR TITLE
Added DevAddr to uplink log line

### DIFF
--- a/pktfwd/network.go
+++ b/pktfwd/network.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/TheThingsNetwork/go-account-lib/account"
 	"github.com/TheThingsNetwork/go-utils/log"
+	"github.com/TheThingsNetwork/packet_forwarder/util"
 	"github.com/TheThingsNetwork/ttn/api/discovery"
 	"github.com/TheThingsNetwork/ttn/api/fields"
 	"github.com/TheThingsNetwork/ttn/api/gateway"
@@ -280,6 +281,12 @@ func (c *TTNClient) queueUplinks() {
 			return
 		case uplink := <-c.uplinkQueue:
 			ctx := c.ctx.WithFields(fields.Get(uplink))
+			if devAddr, err := util.GetDevAddr(uplink); err == nil {
+				ctx = ctx.WithField("DevAddr", devAddr)
+			} else {
+				ctx.WithError(err).Debug("Couldn't identify this uplink's device's DevAddr")
+			}
+
 			if err := c.uplinkStream.Send(uplink); err != nil {
 				ctx.WithError(err).Warn("Uplink message transmission to the back-end failed.")
 			} else {

--- a/util/lorawan.go
+++ b/util/lorawan.go
@@ -1,0 +1,32 @@
+// Copyright © 2017 The Things Network. Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package util
+
+import (
+	"errors"
+
+	"github.com/TheThingsNetwork/ttn/api/router"
+	"github.com/TheThingsNetwork/ttn/core/types"
+	"github.com/brocaar/lorawan"
+)
+
+func GetDevAddr(uplink *router.UplinkMessage) (types.DevAddr, error) {
+	var devAddr [4]byte
+	if uplink == nil {
+		return devAddr, errors.New("Invalid uplink")
+	}
+
+	var phyPayload lorawan.PHYPayload
+	err := phyPayload.UnmarshalBinary(uplink.Payload)
+	if err != nil {
+		return devAddr, err
+	}
+
+	macPayload, ok := phyPayload.MACPayload.(*lorawan.MACPayload)
+	if !ok {
+		return devAddr, errors.New("The uplink doesn't contain a MAC payload")
+	}
+
+	devAddr = types.DevAddr(macPayload.FHDR.DevAddr)
+	return devAddr, nil
+}


### PR DESCRIPTION
The `DevAddr` of the uplink's device, if it can be identified, is now added to the log line when it is transmitted to the network server:

```
  INFO Uplink message transmission successful.  CodingRate=4/5 DataRate=SF7BW125 DevAddr=26012D99 Frequency=867900000 GatewayID=mt-accenture-sim Modulation=LORA PayloadSize=19 RSSI=-70 SNR=9.5
```

This implements the feature request #50.