### PR TITLE
Added Travis file for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+
+go_import_path: github.com/TheThingsNetwork/packet_forwarder
+
+go:
+  - 1.8
+
+install:
+  - make dev-deps
+  - make deps
+
+script:
+  - make quality
+  - HAL_CHOICE=dummy make build # Dummy HAL build


### PR DESCRIPTION
This PR adds a Travis file to the repo. For the moment, the Travis CI file only builds with the dummy Go HAL, to avoid side effects of builds failing because of a wrong environment.