### PR TITLE
corrected =~ condition removing ~ in openssl test

### DIFF
--- a/scripts/kerlink/create-package.sh
+++ b/scripts/kerlink/create-package.sh
@@ -28,7 +28,7 @@ if [[ -z "$BINARY_PATH" ]] ; then
     exit 1
 fi
 
-if [[ $(which openssl) =~ "not found" ]] ; then
+if [[ $(which openssl) = "not found" ]] ; then
     random_string="-$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32};echo;)"
 else
     random_string="-$(date | md5sum | grep -oh -e '[a-zA-Z0-9]*')"


### PR DESCRIPTION
Line 31, changed =~ " 
to just = "
to allow running on Busybox in Kerlink Wirnet Station running either v2.3.3 or v3.1 of the Kerlink System Firmware

Ref https://stackoverflow.com/questions/21010882/how-to-match-regexp-with-ash
to note that bash / ash for busybox has no =~ and to see alternatives...