### PR TITLE
Binary stripping

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,8 @@ cache:
     - go
 
 before_script:
+  # Downloading latest dependencies
+  - apt-get update -y && apt-get install make upx git tar -y
   # Creating release path
   - mkdir release
   # Go build environment variables
@@ -21,7 +23,6 @@ before_script:
   - rm -rf $GOPATH
   - mkdir -p $GOPATH/.cache && ln -s $PWD/.govendor $GOPATH/.cache/govendor
   # Downloading go if not installed yet
-  - apt-get update -y && apt-get install make git tar -y
   - "([[ ! $(go version) =~ \"version\" ]] && apt-get install wget -y && wget https://storage.googleapis.com/golang/go1.8.1.linux-amd64.tar.gz && tar -C $PWD -xvzf go1.8.1.linux-amd64.tar.gz) || echo \"Expected Go toolset available in cache\""
   # Copying the packet-forwarder in the gopath
   - mkdir -p $GOPATH/src/github.com/TheThingsNetwork
@@ -41,6 +42,7 @@ after_script:
   - pushd release_files
   # Change name of the binary
   - mv packet-forwarder* packet-forwarder
+  - upx packet-forwarder
   # Create archive
   - tar -cvzf $CI_JOB_NAME.tar.gz *
   - popd

--- a/.make/go/build.make
+++ b/.make/go/build.make
@@ -29,7 +29,7 @@ else ifeq ($(PLATFORM),kerlink)
 	SENDING_TIME_MARGIN = 60
 endif
 
-LD_FLAGS = -ldflags "-w -X main.version=${PKTFWD_VERSION} -X main.gitCommit=${GIT_COMMIT} -X main.buildDate=${BUILD_DATE} -X github.com/TheThingsNetwork/packet_forwarder/pktfwd.platform=${PLATFORM} -X github.com/TheThingsNetwork/packet_forwarder/cmd.downlinksMargin=${SENDING_TIME_MARGIN}"
+LD_FLAGS = -ldflags "-s -w -X main.version=${PKTFWD_VERSION} -X main.gitCommit=${GIT_COMMIT} -X main.buildDate=${BUILD_DATE} -X github.com/TheThingsNetwork/packet_forwarder/pktfwd.platform=${PLATFORM} -X github.com/TheThingsNetwork/packet_forwarder/cmd.downlinksMargin=${SENDING_TIME_MARGIN}"
 
 # Build the executable
 $(RELEASE_DIR)/$(NAME)-%: $(shell $(GO_FILES)) vendor/vendor.json


### PR DESCRIPTION
This PR adds two stripping operations to the build process, to answer to #68 :

+ In the `make build` process, the `-s` strip Go flag is added. For the Multitech Conduit binary, this reduces the binary size from 11Mb to 9Mb.
+ In the GitLab CI file for the release executables, `upx` is added. For the previous generated binary, it reduces the binary size from 9Mb to 3Mb.

The induced decompression time at startup is also reasonable: for a Multitech Conduit build, the startup time goes from 2.6 seconds to 3.2 seconds.