### PR TITLE
laird: set datarate based off spreading factor

### DIFF
--- a/util/config.go
+++ b/util/config.go
@@ -18,7 +18,7 @@ type ChannelConf struct {
 	IfValue      int32   `json:"if"`
 	Bandwidth    *uint32 `json:"bandwidth,omitempty"`
 	Datarate     *uint32 `json:"datarate,omitempty"`
-	SpreadFactor *uint8  `json:"spread_factor,omitempty"`
+	SpreadFactor *uint32 `json:"spread_factor,omitempty"`
 }
 
 type ChannelFreqConf struct {

--- a/wrapper/concentrator_halV1.go
+++ b/wrapper/concentrator_halV1.go
@@ -228,8 +228,8 @@ func initLoRaStdChannel(stdChan util.ChannelConf) C.struct_lgw_conf_rxif_s {
 		cChannel.bandwidth = C.BW_UNDEFINED
 	}
 
-	if stdChan.Datarate != nil && *stdChan.Datarate >= 7 && *stdChan.Datarate <= 12 {
-		cChannel.datarate = loraChannelSpreadingFactors[*stdChan.Datarate]
+	if stdChan.SpreadFactor != nil && *stdChan.SpreadFactor >= 7 && *stdChan.SpreadFactor <= 12 {
+		cChannel.datarate = loraChannelSpreadingFactors[*stdChan.SpreadFactor]
 	} else {
 		cChannel.datarate = C.DR_UNDEFINED
 	}


### PR DESCRIPTION
In the channels plans the datarate is unspecified however spreading
factor is. We take the SF and map it to the DR bit mask.
Note that 'datarate' is not the raw data rate to use but a bit field.

Bug #72