### PR TITLE
Fixed GPS failing to interact with HAL correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ You can configure a GPS for the packet forwarder in two different manners:
 * With the GPS connected as a serial port: by setting `--gps-path`.
 * With `gpsd`, by adding `--gpsd.enable`. You can specify the address of `gpsd` with `--gpsd.address`. `gpsd` has priority over the serial port.
 
+##### GPS configuration
+
+You can configure a GPS for the packet forwarder in two different manners:
+
+* With the GPS connected as a serial port: by setting `--gps-path`.
+* With `gpsd`, by adding `--gpsd.enable`. You can specify the address of `gpsd` with `--gpsd.address`. `gpsd` has priority over the serial port.
+
 ## <a name="contribute"></a>Contributing
 
 Source code for this packet forwarder is MIT licensed. We encourage users to make contributions on [Github](https://github.com/TheThingsNetwork/packet_forwarder) and to participate in discussions on [Slack](https://www.thethingsnetwork.org/forum/t/slack-invitations/3037/4).

--- a/README.md
+++ b/README.md
@@ -60,13 +60,6 @@ You can configure a GPS for the packet forwarder in two different manners:
 * With the GPS connected as a serial port: by setting `--gps-path`.
 * With `gpsd`, by adding `--gpsd.enable`. You can specify the address of `gpsd` with `--gpsd.address`. `gpsd` has priority over the serial port.
 
-##### GPS configuration
-
-You can configure a GPS for the packet forwarder in two different manners:
-
-* With the GPS connected as a serial port: by setting `--gps-path`.
-* With `gpsd`, by adding `--gpsd.enable`. You can specify the address of `gpsd` with `--gpsd.address`. `gpsd` has priority over the serial port.
-
 ## <a name="contribute"></a>Contributing
 
 Source code for this packet forwarder is MIT licensed. We encourage users to make contributions on [Github](https://github.com/TheThingsNetwork/packet_forwarder) and to participate in discussions on [Slack](https://www.thethingsnetwork.org/forum/t/slack-invitations/3037/4).

--- a/wrapper/gps_HALV1.go
+++ b/wrapper/gps_HALV1.go
@@ -9,6 +9,7 @@ package wrapper
 // #include "loragw_gps.h"
 import "C"
 import (
+	"bufio"
 	"io"
 	"os"
 	"sync"
@@ -94,8 +95,8 @@ func UpdateGPSData(ctx log.Interface) error {
 		ts       C.uint32_t
 		utcTime  C.struct_timespec
 	)
-	buffer := make([]byte, bufferSize)
-	_, err := gps.Read(buffer)
+	reader := bufio.NewReader(gps)
+	buffer, err := reader.ReadBytes('\x0a')
 	if err != nil && err != io.EOF {
 		return errors.Wrap(err, "GPS interface read error")
 	}
@@ -138,7 +139,8 @@ func UpdateGPSData(ctx log.Interface) error {
 
 	ctx.Debug("Fetching GPS coordinates")
 	coordinatesMutex.Lock()
-	ok = C.lgw_gps_get(nil, &coord, &coordErr) != C.LGW_GPS_SUCCESS
+	defer coordinatesMutex.Unlock()
+	ok = C.lgw_gps_get(nil, &coord, &coordErr) == C.LGW_GPS_SUCCESS
 	// For the moment, coordErr is unused, because the back-end doesn't handle the GPS's margin of error.
 	// One possible improvement, if it is handled upstream, would be handling this.
 	if !ok {
@@ -152,8 +154,7 @@ func UpdateGPSData(ctx log.Interface) error {
 		Longitude: float64(coord.lon),
 	}
 	validCoordinates = true
-	ctx.WithFields(log.Fields{"Altitude": coordinates.Altitude, "Latitude": coordinates.Latitude, "Longitude": coordinates.Longitude}).Info("GPS coordinates updated")
-	coordinatesMutex.Unlock()
+	ctx.WithFields(log.Fields{"Altitude": coordinates.Altitude, "Latitude": coordinates.Latitude, "Longitude": coordinates.Longitude}).Debug("GPS coordinates updated")
 	return nil
 }
 

--- a/wrapper/gps_HALV1.go
+++ b/wrapper/gps_HALV1.go
@@ -106,7 +106,7 @@ func UpdateGPSData(ctx log.Interface) error {
 	nmea := C.lgw_parse_nmea(C.CString(gpsRawData), C.int(cap(buffer)))
 	if nmea != C.NMEA_RMC {
 		// No sync to do
-		ctx.Debug("Unknown GPS status")
+		ctx.Debug("GPS ignoring extraneous NMEA message (!= RMC)")
 		return nil
 	}
 


### PR DESCRIPTION
_Can't figure out why git added me to the gpsd readme.md commit, nor how to remove it._

The GPS code in the packet forwarder didn't work for the gateway I'm working on, so I fixed the following errors:

- It was reading 128-byte blocks of NMEA without checking for end-of-line; it now reads one line at a time.
- It used != instead of == when comparing a function return value to its success value, resulting in it rejecting all GPS coordinates.
- It had a deadlock condition on a mutex
- It spammed a misleading message in verbose mode
Those changes are enough to make a Linux tty GPS producing NMEA messages work for me.